### PR TITLE
[Feature #44] 카카오 로그인 수정

### DIFF
--- a/app/src/main/java/com/example/grimmy/ExamTypeFragment.kt
+++ b/app/src/main/java/com/example/grimmy/ExamTypeFragment.kt
@@ -64,16 +64,26 @@ class ExamTypeFragment : Fragment() {
 
     // ✅ 선택된 시험 유형을 ENUM 변환 후 서버에 전송하는 함수
     private fun sendExamTypeToServer(selectedTypes: List<String>) {
+        val sharedPref = requireContext().getSharedPreferences("UserPrefs", Context.MODE_PRIVATE)
+        val userId = sharedPref.getInt("userId", -1) // ✅ 저장된 userId 불러오기
+
+        if (userId == -1) {
+            Log.e("ExamTypeFragment", "❌ 저장된 userId가 없습니다! 요청을 보낼 수 없습니다.")
+            return
+        }
+        Log.i("ExamTypeFragment", "✅ 저장된 userId 사용: $userId")
+
         val examTypeEnums = selectedTypes.mapNotNull { getExamTypeEnum(it) } // 선택된 한글 값을 ENUM으로 변환
 
         if (examTypeEnums.isNotEmpty()) {
-            RetrofitClient.service.updateCategory(CategoryRequest(examTypeEnums.map { it.name })) // ✅ ENUM.name 리스트 전송
+            RetrofitClient.service.updateCategory(userId, CategoryRequest(examTypeEnums.map { it.name })) // ✅ ENUM.name 리스트 전송
                 .enqueue(object : Callback<Void> {
                     override fun onResponse(call: Call<Void>, response: Response<Void>) {
                         if (response.isSuccessful) {
                             Log.i("ExamTypeFragment", "✅ 시험 유형 업데이트 성공! $examTypeEnums")
                         } else {
                             Log.e("ExamTypeFragment", "❌ 시험 유형 업데이트 실패: ${response.code()}")
+                            Log.e("ExamTypeFragment", "❌ 응답 내용: ${response.errorBody()?.string()}")
                         }
                     }
 

--- a/app/src/main/java/com/example/grimmy/GlobalApplication.kt
+++ b/app/src/main/java/com/example/grimmy/GlobalApplication.kt
@@ -1,12 +1,14 @@
 package com.example.grimmy
 
 import android.app.Application
+import com.example.grimmy.Retrofit.RetrofitClient
 import com.kakao.sdk.common.KakaoSdk
 
 class GlobalApplication : Application() {
     override fun onCreate() {
         super.onCreate()
         // 다른 초기화 코드들
+        RetrofitClient.init(this) // ✅ 앱 실행 시 RetrofitClient 초기화
 
         // Kakao SDK 초기화
         KakaoSdk.init(this, BuildConfig.KAKAO_NATIVE_APP_KEY)

--- a/app/src/main/java/com/example/grimmy/NicknameFragment.kt
+++ b/app/src/main/java/com/example/grimmy/NicknameFragment.kt
@@ -82,7 +82,16 @@ class NicknameFragment : Fragment() {
 
     // ✅ 서버에 닉네임 저장 요청
     private fun sendNicknameToServer(nickname: String) {
-        RetrofitClient.service.updateNickname(NicknameRequest(nickname))
+        val sharedPref = requireContext().getSharedPreferences("UserPrefs", Context.MODE_PRIVATE)
+        val userId = sharedPref.getInt("userId", -1) // ✅ 저장된 userId 불러오기
+
+        if (userId == -1) {
+            Log.e("NicknameFragment", "❌ 저장된 userId가 없습니다! 요청을 보낼 수 없습니다.")
+            return
+        }
+        Log.i("NicknameFragment", "✅ 저장된 userId 사용: $userId")
+
+        RetrofitClient.service.updateNickname(userId, NicknameRequest(nickname))
             .enqueue(object : Callback<Void> {
                 override fun onResponse(call: Call<Void>, response: Response<Void>) {
                     if (response.isSuccessful) {

--- a/app/src/main/java/com/example/grimmy/Retrofit/AuthorizationTnterceptor.kt
+++ b/app/src/main/java/com/example/grimmy/Retrofit/AuthorizationTnterceptor.kt
@@ -1,0 +1,34 @@
+package com.example.grimmy.Retrofit
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.util.Log
+import okhttp3.Interceptor
+import okhttp3.Response
+
+class AuthorizationInterceptor(context: Context) : Interceptor {
+    private val sharedPref: SharedPreferences =
+        context.getSharedPreferences("UserPrefs", Context.MODE_PRIVATE)
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val jwtToken = sharedPref.getString("jwtToken", null)
+        val requestBuilder = chain.request().newBuilder()
+
+        if (jwtToken.isNullOrEmpty()) {
+            Log.e("AuthorizationInterceptor", "❌ JWT 토큰이 없습니다! Authorization 헤더 추가 안됨")
+        } else {
+            val tokenHeader = "Bearer $jwtToken"
+            Log.i("AuthorizationInterceptor", "✅ JWT 토큰 추가됨: $tokenHeader")
+            requestBuilder.addHeader("Authorization", tokenHeader)
+        }
+
+        val request = requestBuilder.build()
+
+        // 🔥 요청 로그에 Authorization 헤더가 출력되는지 확인
+        for (headerName in request.headers.names()) {
+            Log.i("AuthorizationInterceptor", "🔍 요청 헤더: $headerName: ${request.headers[headerName]}")
+        }
+
+        return chain.proceed(request)
+    }
+}

--- a/app/src/main/java/com/example/grimmy/Retrofit/Request/KakaoAccessTokenRequest.kt
+++ b/app/src/main/java/com/example/grimmy/Retrofit/Request/KakaoAccessTokenRequest.kt
@@ -1,0 +1,7 @@
+package com.example.grimmy.Retrofit.Request
+
+import com.google.gson.annotations.SerializedName
+
+data class KakaoAccessTokenRequest(
+    @SerializedName("accessToken") val accessToken: String
+)

--- a/app/src/main/java/com/example/grimmy/Retrofit/Response/KakaoAccessTokenResponse.kt
+++ b/app/src/main/java/com/example/grimmy/Retrofit/Response/KakaoAccessTokenResponse.kt
@@ -1,0 +1,8 @@
+package com.example.grimmy.Retrofit.Response
+
+import com.google.gson.annotations.SerializedName
+
+data class KakaoAccessTokenResponse(
+    @SerializedName("accessToken") val accessToken: String,
+    @SerializedName("userId") val userId: Int
+)

--- a/app/src/main/java/com/example/grimmy/Retrofit/RetrofitClient.kt
+++ b/app/src/main/java/com/example/grimmy/Retrofit/RetrofitClient.kt
@@ -1,5 +1,7 @@
 package com.example.grimmy.Retrofit
 
+import android.content.Context
+import android.util.Log
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
 import okhttp3.OkHttpClient
@@ -12,33 +14,51 @@ class RetrofitClient {
 
     companion object {
         private const val BASE_URL = "http://13.124.52.202:8080/"
+        private var appContext: Context? = null
 
+        // ✅ RetrofitClient 초기화 (Application 시작 시 한 번만 호출)
+        fun init(context: Context) {
+            appContext = context.applicationContext
+            Log.i("RetrofitClient", "✅ RetrofitClient 초기화 완료")
+        }
 
-        //추가
+        // ✅ AuthorizationInterceptor 추가
+        private val authorizationInterceptor: AuthorizationInterceptor by lazy {
+            checkNotNull(appContext) { "RetrofitClient.init(context)를 먼저 호출해야 합니다!" }
+            AuthorizationInterceptor(appContext!!)
+        }
+
+        // ✅ HTTP 로그 인터셉터 추가
         private val loggingInterceptor = HttpLoggingInterceptor().apply {
             level = HttpLoggingInterceptor.Level.BODY
         }
 
-        //추가
-        private val okHttpClient = OkHttpClient.Builder()
-            //.addInterceptor(ContentTypeInterceptor())
-            // .connectTimeout(20, TimeUnit.SECONDS)  // 연결 타임아웃 20초
-            // .readTimeout(20, TimeUnit.SECONDS)
-            .addInterceptor(loggingInterceptor)
-            .build()
+        // ✅ OkHttpClient 설정 (JWT 자동 추가)
+        private val okHttpClient: OkHttpClient by lazy {
+            checkNotNull(appContext) { "RetrofitClient.init(context)를 먼저 호출해야 합니다!" }
+
+            OkHttpClient.Builder()
+                .addInterceptor(loggingInterceptor) // 🔥 로그 인터셉터 추가
+                .addInterceptor(authorizationInterceptor) // 🔥 JWT 토큰 자동 추가
+//                .connectTimeout(20, TimeUnit.SECONDS)
+//                .readTimeout(20, TimeUnit.SECONDS)
+                .build()
+        }
 
         val gson: Gson = GsonBuilder()
             .setDateFormat("yyyy-MM-dd") // ✅ 자동 변환 설정
             .create()
 
-        val retrofit: Retrofit = Retrofit.Builder()
-            .baseUrl(this.BASE_URL)
-            .client(okHttpClient) // 추가
-            .addConverterFactory(GsonConverterFactory.create(gson))
-            .build()
+        val retrofit: Retrofit by lazy {
+            Retrofit.Builder()
+                .baseUrl(BASE_URL)
+                .client(okHttpClient) // ✅ JWT 인터셉터가 포함된 클라이언트 사용
+                .addConverterFactory(GsonConverterFactory.create(gson))
+                .build()
+        }
 
-        val service: RetrofitService = retrofit.create(RetrofitService::class.java)
-
-
+        val service: RetrofitService by lazy {
+            retrofit.create(RetrofitService::class.java)
+        }
     }
 }

--- a/app/src/main/java/com/example/grimmy/Retrofit/RetrofitService.kt
+++ b/app/src/main/java/com/example/grimmy/Retrofit/RetrofitService.kt
@@ -5,6 +5,7 @@ import com.example.grimmy.Retrofit.Request.CategoryRequest
 import com.example.grimmy.Retrofit.Request.DailyCommentSaveRequest
 import com.example.grimmy.Retrofit.Request.DailyRecordGetRequest
 import com.example.grimmy.Retrofit.Request.DailyRecordSaveRequest
+import com.example.grimmy.Retrofit.Request.KakaoAccessTokenRequest
 import com.example.grimmy.Retrofit.Request.NicknameRequest
 import com.example.grimmy.Retrofit.Request.StatusRequest
 import com.example.grimmy.Retrofit.Request.TestCommentSaveRequest
@@ -13,13 +14,16 @@ import com.example.grimmy.Retrofit.Request.TestRecordSaveRequest
 import com.example.grimmy.Retrofit.Response.DailyCommentGetResponse
 import com.example.grimmy.Retrofit.Response.DailyRecordGetResponse
 import com.example.grimmy.Retrofit.Response.DailyRecordSaveResponse
+import com.example.grimmy.Retrofit.Response.KakaoAccessTokenResponse
 import com.example.grimmy.Retrofit.Response.MonthlyRecordGetResponse
 import com.example.grimmy.Retrofit.Response.TestCommentGetResponse
 import com.example.grimmy.Retrofit.Response.TestCommentSaveResponse
 import com.example.grimmy.Retrofit.Response.TestRecordGetResponse
 import com.example.grimmy.Retrofit.Response.TestRecordSaveResponse
+import com.kakao.sdk.auth.model.AccessTokenResponse
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
+import okhttp3.ResponseBody
 import retrofit2.Call
 import retrofit2.http.Body
 import retrofit2.http.GET
@@ -31,23 +35,32 @@ import retrofit2.http.PATCH
 import retrofit2.http.Part
 
 interface RetrofitService {
-    @PATCH("user/{userId}/nickname")
+    @POST("/auth/kakao")
+    fun sendAccessToken(
+        @Body request: KakaoAccessTokenRequest
+    ): Call<KakaoAccessTokenResponse>
+
+    @PATCH("/user/{userId}/nickname")
     fun updateNickname(
+        @Path("userId") userId: Int,
         @Body request: NicknameRequest
     ):Call<Void>
 
     @PATCH("/user/{userId}/birthYear")
     fun updateBirthYear(
+        @Path("userId") userId: Int,
         @Body request: BirthRequest
     ):Call<Void>
 
     @PATCH("/user/{userId}/status")
     fun updateStatus(
+        @Path("userId") userId: Int,
         @Body request: StatusRequest
     ):Call<Void>
 
     @PATCH("/user/{userId}/category")
     fun updateCategory(
+        @Path("userId") userId: Int,
         @Body request: CategoryRequest
     ):Call<Void>
 

--- a/app/src/main/java/com/example/grimmy/SplashActivity.kt
+++ b/app/src/main/java/com/example/grimmy/SplashActivity.kt
@@ -21,17 +21,20 @@ class SplashActivity : AppCompatActivity() {
 
         // 2초 후에 SharedPreferences에 저장된 accessToken을 확인하여 다음 화면으로 전환
         Handler(Looper.getMainLooper()).postDelayed({
-            val sharedPref = getSharedPreferences("UserPrefs", Context.MODE_PRIVATE)
-            val accessToken = sharedPref.getString("accessToken", null)
-            Log.d("TokenCheck", "Stored accessToken: $accessToken")
+//            val sharedPref = getSharedPreferences("UserPrefs", Context.MODE_PRIVATE)
+//            val accessToken = sharedPref.getString("accessToken", null)
+//            Log.d("TokenCheck", "Stored accessToken: $accessToken")
 
-            // accessToken이 있으면 이미 가입된 사용자 -> MainActivity로, 없으면 LoginActivity로 이동
-            val nextIntent = if (accessToken != null) {
-                Intent(this, MainActivity::class.java)
-            } else {
-                Intent(this, LoginActivity::class.java)
-            }
-            startActivity(nextIntent)
+//            // accessToken이 있으면 이미 가입된 사용자 -> MainActivity로, 없으면 LoginActivity로 이동
+//            val nextIntent = if (accessToken != null) {
+//                Intent(this, MainActivity::class.java)
+//            } else {
+//                Intent(this, LoginActivity::class.java)
+//            }
+//            startActivity(nextIntent)
+
+            val intent = Intent(this, LoginActivity::class.java)
+            startActivity(intent)
             finish()  // SplashActivity 종료
         }, 2000)
 

--- a/app/src/main/java/com/example/grimmy/StudentStatusFragment.kt
+++ b/app/src/main/java/com/example/grimmy/StudentStatusFragment.kt
@@ -83,9 +83,18 @@ class StudentStatusFragment : Fragment() {
 
     // ✅ 서버에 신분(status) 저장 요청
     private fun sendStatusToServer(status: String) {
+        val sharedPref = requireContext().getSharedPreferences("UserPrefs", Context.MODE_PRIVATE)
+        val userId = sharedPref.getInt("userId", -1) // ✅ 저장된 userId 불러오기
+
+        if (userId == -1) {
+            Log.e("StudentStatusFragment", "❌ 저장된 userId가 없습니다! 요청을 보낼 수 없습니다.")
+            return
+        }
+        Log.i("StudentStatusFragment", "✅ 저장된 userId 사용: $userId")
+
         val statusEnum = getStatusEnum(status)
         if (statusEnum != null) {
-            RetrofitClient.service.updateStatus(StatusRequest(statusEnum.name)) // ✅ ENUM.name 전송
+            RetrofitClient.service.updateStatus(userId, StatusRequest(statusEnum.name)) // ✅ ENUM.name 전송
                 .enqueue(object : Callback<Void> {
                     override fun onResponse(call: Call<Void>, response: Response<Void>) {
                         if (response.isSuccessful) {


### PR DESCRIPTION
## #️⃣연관된 이슈
> #44

## 📝작업 내용
- 카카오 로그인 수정(카카오 계정으로만 로그인 가능)
- 사용자 로그인 시 받는 액세스 토큰을 서버로 보내고, jwt 토큰과 user id를 응답으로 받음. 
- 사용자 정보 관련 api에 path userId 추가

## 🙋🏻 PR 유형
- 새로운 기능 추가
- 버그 수정
- 주석 추가 및 수정
- 파일 혹은 폴더명 수정
